### PR TITLE
Support arbitrary off-screen buffer size

### DIFF
--- a/examples/render_offscreen.py
+++ b/examples/render_offscreen.py
@@ -1,14 +1,14 @@
 #! /usr/bin/env python
 
 import argparse
-
+import numpy as np
 from PIL import Image
 
 import mujoco
 
 parser = argparse.ArgumentParser()
-parser.add_argument('height', type=int)
-parser.add_argument('width', type=int)
+parser.add_argument('--height', type=int)
+parser.add_argument('--width', type=int)
 # parser.add_argument('--video-path', type=str, default='build/video.mp4')
 args = parser.parse_args()
 
@@ -16,6 +16,10 @@ print(args.height, args.width)
 path = 'xml/humanoid.xml'
 
 sim = mujoco.Sim(path, height=args.height, width=args.width)
-for _ in range(10):
-    array = sim.render_offscreen()
-Image.fromarray(array).show()
+try:
+    while True:
+        sim.step()
+        sim.ctrl[:] = -np.ones((sim.ctrl.shape))
+        sim.render_offscreen()
+except KeyboardInterrupt:
+    pass

--- a/examples/render_onscreen.py
+++ b/examples/render_onscreen.py
@@ -1,11 +1,19 @@
 #! /usr/bin/env python
 
 import numpy as np
+import argparse
 
 import mujoco
 
-sim = mujoco.Sim('xml/humanoid.xml', n_substeps=1, height=800)
-while True:
-    sim.step()
-    sim.ctrl[:] = -np.ones((sim.ctrl.shape))
-    sim.render()
+parser = argparse.ArgumentParser()
+parser.add_argument('--height', type=int)
+parser.add_argument('--width', type=int)
+args = parser.parse_args()
+sim = mujoco.Sim('xml/humanoid.xml', n_substeps=1, height=args.height, width=args.width)
+try:
+    while True:
+        sim.step()
+        sim.ctrl[:] = -np.ones((sim.ctrl.shape))
+        sim.render()
+except KeyboardInterrupt:
+    pass

--- a/headers/util.h
+++ b/headers/util.h
@@ -1,6 +1,7 @@
 #ifndef _UTIL_H
 #define _UTIL_H
 
+#include "stdio.h"
 #include "glfw3.h"
 #include "mujoco.h"
 
@@ -13,10 +14,14 @@ typedef struct state_t {
 	mjvOption opt;
 } State;
 
+typedef struct __sFILE FILE;
+
+int openFile(FILE ** fp);
+int closeFile(FILE ** fp);
 int addLabel(const char* label, const float* pos, State* s);
 int initMujoco(const char *filepath, State * state);
 int setCamera(int camid, State * state);
-int renderOffscreen(unsigned char *rgb, int height, int width, State *);
+int renderOffscreen(unsigned char *rgb, int height, int width, State * state, FILE ** fp);
 int closeMujoco(State * state);
 
 #endif

--- a/pxd/util.pxd
+++ b/pxd/util.pxd
@@ -3,6 +3,8 @@ include "mjvisualize.pxd"
 include "mjrender.pxd"
 
 cdef extern from "util.h":
+    ctypedef struct FILE
+
     ctypedef struct State:
         mjModel * m
         mjData * d
@@ -19,8 +21,10 @@ cdef extern from "util.h":
         double mouseDy
         char lastKeyPress
 
+    int openFile(FILE ** fp)
+    int closeFile(FILE ** fp)
     int initMujoco(const char *filepath, State * state)
     int setCamera(int camid, State * state)
     int addLabel(const char* label, float* pos, State* s)
-    int renderOffscreen(unsigned char *rgb, int height, int width, State *)
+    int renderOffscreen(unsigned char *rgb, int height, int width, State * state, FILE ** fp)
     int closeMujoco(State * state)


### PR DESCRIPTION
- Unified the on & off-screen rendering simulation in examples/
- Added C file struct to store off-screen buffer rgb arrays
- Added a function in sim.pyx to support arbitrary off-screen buffer size